### PR TITLE
fix:fix bugs in Issue #5

### DIFF
--- a/lingLong/src/components/misc/CopyRight.astro
+++ b/lingLong/src/components/misc/CopyRight.astro
@@ -37,11 +37,22 @@ const { title, published, license, author, sourceLink } = Astro.props;
         <span class="select-none text-sm text-[var(--text-color-lighten)]"
           >{i18n(I18nKeys.copy_right_author)}</span
         >
-        <p
-          class="username !my-0 line-clamp-1 text-sm text-[var(--text-color)] lg:text-base"
-        >
-          {author ?? LingLongConfig.username}
-        </p>
+        {sourceLink?(
+          <a 
+            href={sourceLink}
+            target="_blank" 
+            rel="noopener noreferrer"
+            class="username !my-0 line-clamp-1 text-sm text-[var(--text-color)] lg:text-base"
+          >
+            {author ?? LingLongConfig.username}
+          </a>
+          ) : (
+          <p 
+            class="username !my-0 line-clamp-1 text-sm text-[var(--text-color)] lg:text-base"
+          >
+            {author ?? LingLongConfig.username}
+          </p>
+        )}
       </div>
       <div class="flex flex-col">
         <span class="select-none text-sm text-[var(--text-color-lighten)]"
@@ -108,7 +119,7 @@ const { title, published, license, author, sourceLink } = Astro.props;
   }
 
   .username{
-    @apply text-center text-transparent
+    @apply text-center !text-transparent
            bg-gradient-to-r  from-blue-500 via-purple-500 to-pink-500
            bg-clip-text
            ;

--- a/lingLong/src/layouts/PostLayout.astro
+++ b/lingLong/src/layouts/PostLayout.astro
@@ -26,6 +26,8 @@ const {
   author,
   sourceLink,
 } = Astro.props;
+
+console.log(sourceLink ?? "no source")
 ---
 
 <Main title={title} subTitle={subTitle} bannerImage={bannerImage}>

--- a/lingLong/src/pages/posts/[...slug].astro
+++ b/lingLong/src/pages/posts/[...slug].astro
@@ -3,6 +3,8 @@ import { getCollection } from "astro:content";
 import { IdToSlug } from "../../utils/hash";
 import PostLayout from "../../layouts/PostLayout.astro";
 import { render } from "astro:content";
+import { en } from "../../locales/languages/en";
+import LingLongConfig from "../../../linglong.config";
 
 
 // 所有单篇博客文章的最终渲染模板。
@@ -11,11 +13,11 @@ import { render } from "astro:content";
 // 但在这个项目的上下文中，它的作用和 [slug].astro 几乎一样：
 // 为每一篇文章生成一个唯一的页面。slug 通常指代文章的URL友好型短名称。
 
-// 1.  `getStaticPaths` 扫描所有 `.md` 文件。
-// 2.  对于每一篇 `.md` 文件，它都用 `IdToSlug` 函数为其生成一个独特的 URL (`slug`)。
+// 1.  getStaticPaths 扫描所有 .md 文件
+// 2.  对于每一篇 md 文件，它都用 IdToSlug 函数为其生成一个独特的 URL (slug)
 // 3.  然后它告诉 Astro：“请使用本文件作为模板，为这个 URL 创建一个页面，
-//     并把这篇文章的全部数据 (`entry`) 传递给模板。”
-// 4.  模板接收到特定文章的 `entry` 数据，并使用 `render` 函数准备好文章正文（`<Content />`）。
+//     并把这篇文章的全部数据 (entry) 传递给模板。”
+// 4.  模板接收到特定文章的 entry 数据，并使用 render 函数准备好文章正文`<Content />）
 export async function getStaticPaths() {
   const postEntries = await getCollection("posts");
   return postEntries.map((entry) => ({
@@ -27,11 +29,26 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 // 使用Astro内置功能获取标题数据，无需额外插件
 const { Content, headings } = await render(entry);
+
 ---
 
+
+<!-- 
+如果一篇文章是原创的（你没有在 frontmatter 里加 licenseName），它就用一个简洁的布局来展示。
+如果一篇文章是转载的（你在 frontmatter 里加了 licenseName 等信息），
+它就会在布局中自动包含作者、来源链接、许可协议等额外信息。
+无论哪种情况，文章的正文都通过 <Content /> 组件被精确地插入到布局的正确位置。
+同时，它还为 Pagefind 搜索工具准备了隐藏的元数据，以便用户可以搜索到这篇文章 -->
 {
-  !entry.data.licenseName && (
+  // 原创
+  // 查看判断条件：发现是根据 licenseName 判断是否是转载，
+  // 因此就算在 frontmatter 里写 'author'，也不会在文章的许可证处显示作者
+  !entry.data.sourceLink && (
     <>
+    {/*
+    增加 author 一栏 即可实现，但这显得过于杂乱：JuyaoHuang、Alen都指向同一人。
+    因此以后编写文章时，如果是自制，formatter 不需要再加 "author"
+    */}
       <PostLayout
         title={entry.data.title}
         subTitle={entry.data.description}
@@ -54,19 +71,14 @@ const { Content, headings } = await render(entry);
   )
 }
 {
-// 如果一篇文章是原创的（你没有在 frontmatter 里加 licenseName），它就用一个简洁的布局来展示。
-// 如果一篇文章是转载的（你在 frontmatter 里加了 licenseName 等信息），
-// 它就会在布局中自动包含作者、来源链接、许可协议等额外信息。
-// 无论哪种情况，文章的正文都通过 <Content /> 组件被精确地插入到布局的正确位置。
-// 同时，它还为 Pagefind 搜索工具准备了隐藏的元数据，以便用户可以搜索到这篇文章
-  entry.data.licenseName && (
+  entry.data.sourceLink && (
     <>
       <PostLayout
         title={entry.data.title}
         subTitle={entry.data.description}
         bannerImage={entry.data.cover}
         published={entry.data.published}
-        license={{ name: entry.data.licenseName, url: entry.data.licenseUrl }}
+        license={{ name: entry.data.licenseName ?? LingLongConfig.license.name, url: entry.data.licenseUrl ?? LingLongConfig.license.url}}
         author={entry.data.author}
         sourceLink={entry.data.sourceLink}
       >


### PR DESCRIPTION
## Major changes:
The categorization logic for reprinted and self-made articles has been optimized, and the display logic of the article footer in the script 'lingLong\src\components\misc\CopyRight.astro' has been modified. 
1. Add notes in lingLong\src\pages\posts\[...slug].astro to describe different situation with "self-made" and "reprinted". 
2. Fix bug: When an article is reprinted and souce link is existed, but the footer does not provide related link. Related:lingLong\src\components\misc\CopyRight.astro

Related Issue #5 
