### PR TITLE
feat: add colored text remark plugin

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,6 +11,7 @@ import remarkGfm from 'remark-gfm'
 // npm install astro-mermaid mermaid --registry=https://registry.npmmirror.com/
 // Local integrations
 import rehypeAutolinkHeadings from './src/plugins/rehype-auto-link-headings.ts'
+import remarkColoredText from './src/plugins/remark-colored-text.ts'
 // Shiki
 import {
   addCollapse,
@@ -57,7 +58,7 @@ export default defineConfig({
 
   // [Markdown]
   markdown: {
-    remarkPlugins: [remarkMath, remarkGfm],
+    remarkPlugins: [remarkMath, remarkGfm, remarkColoredText],
     rehypePlugins: [
       [rehypeKatex, {}],
       rehypeHeadingIds,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chart.js": "^4.5.1",
     "katex": "^0.16.27",
     "lxgw-wenkai-screen-webfont": "^1.7.0",
+    "mdast-util-find-and-replace": "^3.0.2",
     "mermaid": "^11.12.2",
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       lxgw-wenkai-screen-webfont:
         specifier: ^1.7.0
         version: 1.7.0
+      mdast-util-find-and-replace:
+        specifier: ^3.0.2
+        version: 3.0.2
       mermaid:
         specifier: ^11.12.2
         version: 11.12.2

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -270,6 +270,44 @@ span.katex-display {
   }
 }
 
+/* [Colored Text] */
+:root {
+  --ct-red: #EF4444;
+  --ct-blue: #3B82F6;
+  --ct-green: #22C55E;
+  --ct-yel: #EAB308;
+  --ct-pur: #A855F7;
+  --ct-gray: #6B7280;
+  --ct-pink: #F472B6;
+  --ct-emer: #10B981;
+  --ct-rose: #FB7185;
+  --ct-vio: #A78BFA;
+}
+.dark {
+  --ct-red: #F87171;
+  --ct-blue: #60A5FA;
+  --ct-green: #4ADE80;
+  --ct-yel: #FACC15;
+  --ct-pur: #C084FC;
+  --ct-gray: #9CA3AF;
+  --ct-pink: #F9A8D4;
+  --ct-emer: #34D399;
+  --ct-rose: #FDA4AF;
+  --ct-vio: #C4B5FD;
+}
+.ct-red { color: var(--ct-red) !important; }
+.ct-blue { color: var(--ct-blue) !important; }
+.ct-green { color: var(--ct-green) !important; }
+.ct-yel { color: var(--ct-yel) !important; }
+.ct-pur { color: var(--ct-pur) !important; }
+.ct-gray { color: var(--ct-gray) !important; }
+.ct-pink { color: var(--ct-pink) !important; }
+.ct-emer { color: var(--ct-emer) !important; }
+.ct-rose { color: var(--ct-rose) !important; }
+.ct-vio { color: var(--ct-vio) !important; }
+/* Force child elements (strong, em, a, etc.) to inherit colored text */
+[class^="ct-"] * { color: inherit !important; }
+
 /* Scroll bar */
 :root {
   --scrollbar-thumb: hsl(var(--muted-foreground) / var(--un-bg-opacity, 0.3));

--- a/src/plugins/remark-colored-text.ts
+++ b/src/plugins/remark-colored-text.ts
@@ -1,0 +1,30 @@
+/**
+ *彩色文本语法备注插件：{color}text{/color}
+ *
+ *支持的颜色：红、蓝、绿、yel、pur、灰色、粉色、emer、rose、vio
+ *
+ *.md 文件中的用法：
+ *{red}此文字为红色{/red}
+ *{blue}**蓝色粗体文本**{/blue}
+ *
+ *注意：此插件发出可在 .md 文件中工作的原始 HTML 节点。
+ *它不适用于 .mdx 文件，因为 MDX 管道会剥离原始 HTML
+ *通过 rehypeRemoveRaw 的节点。
+ */
+import type { Root } from 'mdast'
+import { findAndReplace } from 'mdast-util-find-and-replace'
+
+const COLORS = ['red', 'blue', 'green', 'yel', 'pur', 'gray', 'pink', 'emer', 'rose', 'vio'] as const
+
+const colorPattern = COLORS.join('|')
+const openRegex = new RegExp(`\\{(${colorPattern})\\}`, 'g')
+const closeRegex = new RegExp(`\\{/(${colorPattern})\\}`, 'g')
+
+export default function remarkColoredText() {
+  return (tree: Root) => {
+    findAndReplace(tree, [
+      [openRegex, (_: string, color: string) => ({ type: 'html' as const, value: `<span class="ct-${color}">` })],
+      [closeRegex, () => ({ type: 'html' as const, value: '</span>' })]
+    ])
+  }
+}


### PR DESCRIPTION
## Summary
- Add custom remark plugin supporting `{color}text{/color}` syntax for colored text in `.md` files
- Support 10 predefined colors: red, blue, green, yel, pur, gray, pink, emer, rose, vio
- Dark mode auto-adaptation via CSS custom properties (light/dark hex values)
- Compatible with existing Markdown formatting (bold, italic, links inside colored spans)

## Changes
- `src/plugins/remark-colored-text.ts` — New remark plugin using `findAndReplace`
- `src/assets/styles/global.css` — CSS variables + `.ct-*` classes
- `astro.config.ts` — Register plugin in remarkPlugins array
- `package.json` — Add `mdast-util-find-and-replace` as direct dependency

## Usage
```markdown
{red}This text is red{/red}
{blue}**Bold blue text**{/blue}
{pink}pink words{/pink} in a sentence
```

## Test plan
- [x] All 10 colors render correctly in light mode
- [x] Dark mode toggle switches to dark hex values
- [x] Bold, italic, and links inside colored spans render correctly
- [x] No interference with existing plugins (math, code blocks, GFM)
- [x] Build passes with 0 errors