### PR TITLE
feat: optimize code rendering styles

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -144,6 +144,11 @@ span.katex-display {
     top: 0.75rem;
     right: 0;
   }
+  @media (max-width: 640px) {
+    & .language {
+      display: none;
+    }
+  }
 
   /* Copy */
   & button.copy {

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -157,7 +157,7 @@ export const integ: IntegrationUserConfig = {
     blockquoteStyle: 'italic',
     // The style of inline code block `code` / `modern` (default to code in typography)
     // 行内代码样式: 'code' / 'modern'
-    inlineCodeBlockStyle: 'code'
+    inlineCodeBlockStyle: 'modern'
   },
   // [Lightbox]
   // A lightbox library that can add zoom effect

--- a/执行准则.md
+++ b/执行准则.md
@@ -1,0 +1,205 @@
+# 执行准则
+
+> 本文档定义 agent 在前端项目中编写代码时必须遵循的流程和规范。每次编写/修改代码后，按此清单执行。
+
+---
+
+## 代码编写后的检查清单
+
+每次编写或修改代码后，按顺序执行以下步骤：
+
+### 1. 类型检查
+
+```bash
+# 确保没有 TypeScript 类型错误
+npm run type-check
+# 或
+npx vue-tsc --noEmit
+```
+
+### 2. 代码格式化和检查
+
+```bash
+# ESLint 检查和自动修复
+npm run lint
+# 或
+npx eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix
+
+# Prettier 格式化（如果配置了）
+npm run format
+# 或
+npx prettier --write .
+```
+
+### 3. 依赖检查
+
+- 确认新增的 import 都在 `package.json` 的依赖中
+- 如果引入了新依赖：`npm install <package>`
+- 区分 `dependencies`（运行时依赖）和 `devDependencies`（开发依赖）
+
+### 4. 构建验证
+
+```bash
+# 确保构建成功
+npm run build
+```
+
+- 检查构建产物大小（`dist/` 目录）
+- 确保没有构建警告或错误
+
+### 5. 设计一致性
+
+- 检查实现是否与设计文档一致
+- 如果实现中发现设计需要调整，先更新设计文档，再改代码
+- 不要偏离设计文档中已确定的决策（如状态管理结构、API 对接方式等）
+
+---
+
+## 编码规范
+
+### 命名
+
+- **文件名**: `PascalCase.vue`（组件）/ `camelCase.ts`（工具/类型）/ `kebab-case.css`（样式）
+- **组件名**: `PascalCase`（如 `ChatArea.vue`）
+- **函数/变量**: `camelCase`
+- **常量**: `UPPER_SNAKE_CASE`
+- **类型/接口**: `PascalCase`（如 `interface ChatState`）
+- **Composables**: `use` 前缀（如 `useChat.ts`）
+- **Stores**: 模块名（如 `chat.ts`，导出 `useChatStore`）
+
+### 组件结构
+
+每个 Vue 组件遵循标准结构：
+
+```vue
+<script setup lang="ts">
+// 1. imports
+import { ref, computed } from 'vue'
+import { useChatStore } from '@/stores/chat'
+
+// 2. props/emits
+interface Props {
+  message: string
+}
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  send: [text: string]
+}>()
+
+// 3. composables
+const chatStore = useChatStore()
+
+// 4. reactive state
+const inputText = ref('')
+
+// 5. computed
+const isDisabled = computed(() => !inputText.value.trim())
+
+// 6. methods
+const handleSend = () => {
+  emit('send', inputText.value)
+  inputText.value = ''
+}
+
+// 7. lifecycle hooks
+onMounted(() => {
+  // ...
+})
+</script>
+
+<template>
+  <!-- 模板内容 -->
+</template>
+
+<style scoped>
+/* 组件样式（优先使用 UnoCSS 原子类） */
+</style>
+```
+
+### 状态管理（Pinia）
+
+- 每个 store 独立文件，按功能模块划分
+- store 命名：`use<Module>Store`（如 `useChatStore`）
+- state 使用箭头函数返回初始状态
+- actions 处理异步逻辑和状态更新
+- getters 用于派生状态（优先使用 computed）
+
+### 样式规范
+
+- **优先使用 UnoCSS 原子类**（如 `class="flex items-center gap-4"`）
+- 组件特定样式使用 `<style scoped>`
+- 全局样式放在 `src/assets/styles/main.css`
+- 避免内联样式（`style="..."`）
+
+### TypeScript
+
+- 所有文件使用 TypeScript（`.ts` / `.vue`）
+- 为 props、emits、函数参数、返回值添加类型
+- 避免使用 `any`，优先使用具体类型或 `unknown`
+- 复杂类型定义放在 `src/types/` 目录
+
+### 异步处理
+
+- API 调用使用 `async/await`
+- WebSocket 事件监听使用回调函数
+- 错误处理使用 `try/catch`
+- 加载状态使用 `loading` 标志
+
+---
+
+## 代码审查
+
+在提交 PR 前，启动 **`/omc-code-review`** 进行自我审查：
+
+1. **功能完整性**：是否实现了 User Story 中的所有功能点
+2. **类型安全**：是否所有变量和函数都有正确的类型
+3. **错误处理**：是否处理了 API 调用失败、WebSocket 断线等异常情况
+4. **性能优化**：是否有不必要的重复渲染、内存泄漏
+5. **用户体验**：是否有加载状态、错误提示、空状态展示
+6. **代码复用**：是否有重复代码可以提取为 composable 或组件
+7. **注释文档**：复杂逻辑是否有注释说明
+
+---
+
+## 提交规范
+
+- 在开始实现前，执行 `git checkout -b feat/changes_name` 切换分支，在新分支上开发
+- 每个 Step 一个 commit，不要把多个不相关的改动混在一起。例如 step1->commit 1;step 2->commit 2
+- commit message 格式：`<type>: <description>`
+- 示例：`feat: add WebSocket manager and real-time chat functionality`
+- **注意**：commit 内容应该简洁，重点描述做了什么，不附带任何的 AI 协助信息
+- Note：使用 `git commit --no-gpg-sign` 进行提交，忽略 GPG 签名
+- 在实现功能后，等待负责人验收
+- 验收结束后，执行 `git push` 推送到上游仓库，并且执行 `gh pr` 提交 PR
+
+## 性能优化
+
+### 组件优化
+
+- 使用 `v-memo` 缓存列表项
+- 使用 `v-once` 渲染静态内容
+- 使用 `v-show` 代替 `v-if`（频繁切换）
+- 使用 `<KeepAlive>` 缓存路由组件
+
+### 状态优化
+
+- 避免在 computed 中执行复杂计算
+- 使用 `shallowRef` / `shallowReactive` 优化大对象
+- 及时清理事件监听器和定时器
+
+### 资源优化
+
+- 图片使用 WebP 格式
+- 懒加载路由组件（`() => import('./Component.vue')`）
+- 使用 CDN 加载大型依赖
+
+---
+
+## 禁止项
+
+- 不要使用 `any` 类型（除非确实无法推断）
+- 不要在 `<template>` 中写复杂逻辑（提取到 computed 或 methods）
+- 不要忽略 TypeScript 类型错误（必须修复）
+- 不要忽略 ESLint 警告（必须修复或合理禁用）
+- 不要提交 `node_modules/` 或 `dist/` 目录
+- 不要在 commit message 中包含 AI 协助信息


### PR DESCRIPTION
## Summary
- Hide Shiki code block language labels on screens up to 640px wide.
- Update inline code rendering configuration to use the modern style.
- Add the project execution guidelines document.

## Validation
- `npm run check` passed with 0 errors and existing hints.
- `npm run build` did not complete because `@astrojs/vercel` failed during `astro:build:done` on Windows with `EPERM` while creating a symlink for `clsx` under `.vercel/output/functions/_render.func/node_modules`.