### PR TITLE
perf: prerender public pages and defer poetry font

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,6 +25,7 @@ const {
   <head>
     <BaseHead {articleDate} {description} {ogImage} {title} />
     <ThemeProvider />
+    <slot name='head' />
   </head>
 
   <body class='flex justify-center bg-background text-foreground' {...props}>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,7 +4,7 @@ import type { CollectionEntry } from 'astro:content'
 
 // Plugin styles
 import 'katex/dist/katex.min.css'
-import 'lxgw-wenkai-screen-webfont/style.css'
+import lxgwWenkaiCssUrl from 'lxgw-wenkai-screen-webfont/style.css?url'
 
 import { MediumZoom } from 'astro-pure/advanced'
 import { ArticleBottom, Copyright, Hero, TOC } from 'astro-pure/components/pages'
@@ -51,6 +51,10 @@ const isPoetrySharePost = data.first_level_category === '诗词分享'
   highlightColor={primaryColor}
   back='/blog'
 >
+  <Fragment slot='head'>
+    {isPoetrySharePost && <link rel='stylesheet' href={lxgwWenkaiCssUrl} />}
+  </Fragment>
+
   {!!headings.length && <TOC {headings} slot='sidebar' />}
 
   <Hero {data} {remarkPluginFrontmatter} slot='header'>

--- a/src/layouts/ContentLayout.astro
+++ b/src/layouts/ContentLayout.astro
@@ -16,6 +16,10 @@ const { meta, highlightColor, back = '/', ...props } = Astro.props
 ---
 
 <PageLayout {meta} {highlightColor} {...props}>
+  <Fragment slot='head'>
+    <slot name='head' />
+  </Fragment>
+
   <Button title='Back' href={back} variant='back' />
   <main class='mt-6 items-start gap-x-10 md:flex'>
     {/* Sidebar */}

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -4,6 +4,8 @@ import { cn } from 'astro-pure/utils'
 import PageLayout from '@/layouts/BaseLayout.astro'
 import { getFirstCategories } from '@/utils/categories'
 
+export const prerender = true
+
 const categoriesMap = await getFirstCategories()
 const allCategories = [...categoriesMap.values()].map(category => ({
   name: category.name,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,6 +16,8 @@ import NnsImg from '@/assets/education/nnsz.png'
 import Atri_light from '@/assets/backgrounds/atri-light.jpg'
 import Atri_dark from '@/assets/backgrounds/atri-dark.jpg'
 
+export const prerender = true
+
 // Background mode from site config ('gradient' or 'image')
 const backgroundMode = config.homepageBackground || 'gradient'
 

--- a/src/pages/links/index.astro
+++ b/src/pages/links/index.astro
@@ -6,6 +6,8 @@ import config from 'virtual:config'
 import PageLayout from '@/layouts/CommonPage.astro'
 import FriendList from '@/components/links/FriendList.astro'
 
+export const prerender = true
+
 const headings = [
   { depth: 2, slug: 'common-links', text: 'Common Links' },
   { depth: 2, slug: 'special-links', text: 'Special Links' },

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -10,6 +10,8 @@ import alipay from '@/assets/alipay-qrcode.jpg'
 import KeyIcon from '@/assets/icons/key.svg'
 import wechat from '@/assets/wechat-qrcode.jpg'
 
+export const prerender = true
+
 const headings = [
   { depth: 2, slug: 'programs', text: 'Programs' },
   { depth: 2, slug: 'learnings', text: 'Learnings' },

--- a/src/pages/search/index.astro
+++ b/src/pages/search/index.astro
@@ -4,6 +4,8 @@ import { Button } from 'astro-pure/user'
 import PageLayout from '@/layouts/BaseLayout.astro'
 import { integ } from '@/site-config'
 
+export const prerender = true
+
 const meta = {
   description: 'Search relative posts of the whole blog',
   title: 'Search'

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -4,6 +4,8 @@ import { Button } from 'astro-pure/user'
 import { cn } from 'astro-pure/utils'
 import PageLayout from '@/layouts/BaseLayout.astro'
 
+export const prerender = true
+
 const allPosts = await getBlogCollection()
 const allTags = getUniqueTagsWithCount(allPosts)
 


### PR DESCRIPTION
## Summary
- prerender selected public pages: home, projects, links, search, tags index, and categories index
- add a layout head slot so page-specific styles can be injected cleanly
- load the LXGW WenKai stylesheet only for poetry posts instead of every blog post

## Validation
- `pnpm check` passed
- verified generated static HTML exists for the newly prerendered public pages
- verified generated HTML links the WenKai stylesheet on poetry posts, but not on non-poetry posts or the selected public pages

## Notes
- About page and Substats behavior are intentionally unchanged
- Local `pnpm build` may require Windows Developer Mode or an elevated shell because the Vercel adapter creates symlinks while bundling functions