### PR TITLE
fix: preserve blog entry route on back navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ bunfig.toml
 .claude/
 .omc/
 null
+.gitnexus/

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,13 +4,15 @@ import type { CollectionEntry } from 'astro:content'
 
 // Plugin styles
 import 'katex/dist/katex.min.css'
+
 import lxgwWenkaiCssUrl from 'lxgw-wenkai-screen-webfont/style.css?url'
+import config from 'virtual:config'
 
 import { MediumZoom } from 'astro-pure/advanced'
 import { ArticleBottom, Copyright, Hero, TOC } from 'astro-pure/components/pages'
-import config from 'virtual:config'
 import PageLayout from '@/layouts/ContentLayout.astro'
 import { Comment, PageInfo } from '@/components/waline'
+import { IdToSlug } from '@/utils/slug'
 
 interface Props {
   post: CollectionEntry<'blog'>
@@ -44,12 +46,22 @@ const socialImage = heroImage
 const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString()
 const primaryColor = data.heroImage?.color ?? 'hsl(var(--primary) / var(--un-text-opacity))'
 const isPoetrySharePost = data.first_level_category === '诗词分享'
+const firstCategorySlug = data.first_level_category?.trim()
+  ? IdToSlug(data.first_level_category)
+  : ''
+const secondCategorySlug = data.second_level_category?.trim()
+  ? IdToSlug(data.second_level_category)
+  : ''
+const categoryBackPath =
+  firstCategorySlug && secondCategorySlug
+    ? `/categories/${firstCategorySlug}/${secondCategorySlug}`
+    : '/blog'
 ---
 
 <PageLayout
   meta={{ articleDate, description, ogImage: socialImage, title }}
   highlightColor={primaryColor}
-  back='/blog'
+  back={categoryBackPath}
 >
   <Fragment slot='head'>
     {isPoetrySharePost && <link rel='stylesheet' href={lxgwWenkaiCssUrl} />}
@@ -72,8 +84,7 @@ const isPoetrySharePost = data.first_level_category === '诗词分享'
     <Copyright {data} />
     {/* Article recommend */}
     <ArticleBottom collections={posts} {id} class='mt-3 sm:mt-6' />
-    { /* Comment */
-    !isDraft && enableComment && <Comment class='mt-3 sm:mt-6' />}
+    {/* Comment */ !isDraft && enableComment && <Comment class='mt-3 sm:mt-6' />}
   </Fragment>
 
   <slot name='bottom-sidebar' slot='bottom-sidebar' />


### PR DESCRIPTION
## Summary\n- generate blog post Back links from the post's category metadata\n- fall back to /blog when category metadata is incomplete\n- add .gitnexus/ to gitignore\n\n## Verification\n- pnpm check passes with 0 errors\n- targeted ESLint passes\n- built article output contains /categories/知识库/通信原理\n- full pnpm build reaches page generation but the Vercel adapter finish step is blocked by Fontshare network access and Windows symlink permissions in the environment\n\n## Scope\n- excludes existing src/content/blog submodule changes\n